### PR TITLE
fix: add date frontmatter and trailing-slash permalinks to 3 articles

### DIFF
--- a/src/articles/beyondtrust-rce-cve-2026-1731.njk
+++ b/src/articles/beyondtrust-rce-cve-2026-1731.njk
@@ -1,8 +1,9 @@
 ---
 title: 'BeyondTrust Pre-Auth RCE (CVE-2026-1731): WebSocket OS Command Injection Hits 8,500+ Vulnerable Instances'
 description: 'CVSS 9.9 pre-authentication RCE in BeyondTrust Remote Support and Privileged Remote Access enables OS command injection via unauthenticated WebSocket. 8,500+ vulnerable instances globally — patch or restrict now.'
+date: 2026-02-19
 layout: base.njk
-permalink: /articles/beyondtrust-rce-cve-2026-1731.html
+permalink: /articles/beyondtrust-rce-cve-2026-1731/
 ---
 
 <article>

--- a/src/articles/firefox-spidermonkey-wasm-gc-rce.njk
+++ b/src/articles/firefox-spidermonkey-wasm-gc-rce.njk
@@ -1,8 +1,9 @@
 ---
 title: 'Firefox SpiderMonkey WebAssembly GC RCE: One Typo, Full Renderer Compromise'
 description: 'A single & vs | typo in Firefox SpiderMonkey''s Wasm GC engine causes a type confusion leading to RCE in the renderer process — affecting 200M+ users via any malicious webpage.'
+date: 2026-02-23
 layout: base.njk
-permalink: /articles/firefox-spidermonkey-wasm-gc-rce.html
+permalink: /articles/firefox-spidermonkey-wasm-gc-rce/
 ---
 
 <article>

--- a/src/articles/gcp-vertex-ai-bucket-squatting-cve-2026-2473.njk
+++ b/src/articles/gcp-vertex-ai-bucket-squatting-cve-2026-2473.njk
@@ -1,8 +1,9 @@
 ---
 title: 'CVE-2026-2473: GCP Vertex AI Bucket Squatting Enables Cross-Tenant RCE and Model Theft (CVSS 9.8)'
 description: 'Google patched a critical Vertex AI vulnerability where predictable Cloud Storage bucket names allowed unauthenticated attackers to steal AI models, poison training pipelines, and execute code across tenant boundaries.'
+date: 2026-02-22
 layout: base.njk
-permalink: /articles/gcp-vertex-ai-bucket-squatting-cve-2026-2473.html
+permalink: /articles/gcp-vertex-ai-bucket-squatting-cve-2026-2473/
 ---
 
 <article>


### PR DESCRIPTION
## What

Fix frontmatter issues in three articles flagged by Kirk after PR #1 merged.

**Articles fixed:**
- `beyondtrust-rce-cve-2026-1731`
- `firefox-spidermonkey-wasm-gc-rce`
- `gcp-vertex-ai-bucket-squatting-cve-2026-2473`

**Changes per article:**
- Added missing `date:` frontmatter (sourced from each article's published date in the article-meta paragraph)
- Changed `permalink:` from `.html` suffix to trailing slash (consistent with all other articles on the site)

## Why

Inconsistent permalink formats break internal links and can cause duplicate-URL issues. Missing `date:` frontmatter prevents Eleventy from sorting/filtering articles by date correctly.

## Test

Build + verify permalinks resolve correctly. No deploy required — Kirk merges then deploy-to-s3.sh runs.