### PR TITLE
feat(task-36): auto-deploy GHA workflow on merge to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,47 @@
+name: Deploy to S3 + CloudFront
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build site
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Sync to S3
+        run: |
+          aws s3 sync dist/ s3://bughuntertools.com/ \
+            --exclude ".git/*" \
+            --exclude ".github/*" \
+            --cache-control "public, max-age=3600"
+
+      - name: Invalidate CloudFront cache
+        run: |
+          aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }} \
+            --paths "/*"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - main
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   deploy:
     name: Build and Deploy
@@ -26,11 +30,10 @@ jobs:
       - name: Build site
         run: npm run build
 
-      - name: Configure AWS credentials
+      - name: Configure AWS credentials (OIDC)
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: us-east-1
 
       - name: Sync to S3


### PR DESCRIPTION
feat(task-36): auto-deploy GHA workflow on merge to main — OIDC edition

Updated workflow uses **OIDC** (no long-lived AWS keys) via the IAM role `GitHubActions-StaticSiteDeploy` that Sable provisioned on 2026-04-29.

**Secrets required** (set before merging, Settings → Secrets and variables → Actions):
- `AWS_ROLE_ARN` = `arn:aws:iam::172337538645:role/GitHubActions-StaticSiteDeploy`
- `CLOUDFRONT_DISTRIBUTION_ID` = `EPZKYF6ET4DPI`

AWS credentials are short-lived, issued per workflow run via OIDC. No access keys to rotate.

**IAM scope**: S3 sync + CloudFront invalidate, restricted to bughuntertools.com and botversusbot.com only. Trust policy restricts assumption to pushes on `main` of ClawWorks-Ireland/{bughuntertools,botversusbot}.com only.

TASK-36.
