### PR TITLE
feat: add AdSense auto-ads script to base layout (all pages)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -45,6 +45,11 @@ const pathname = Astro.url.pathname;
     <meta name="twitter:description" content={description}>
 
     <link rel="stylesheet" href="/css/style.css">
+
+    <!-- Google AdSense auto-ads -->
+    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9373816755142401"
+     crossorigin="anonymous"></script>
+
     <!-- Preconnect to GA domains for faster loading -->
     <link rel="preconnect" href="https://www.googletagmanager.com">
     <link rel="preconnect" href="https://www.google-analytics.com">


### PR DESCRIPTION
## Summary

Adds Google AdSense auto-ads script to `src/layouts/BaseLayout.astro` so it renders on every page site-wide.

**Change:**
- Script added just before `</head>` in the base layout component
- Single point of truth — no per-page changes needed

**Exact tag (from Delmar):**
```html
<script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9373816755142401"
 crossorigin="anonymous"></script>
```

**Build:** `astro build` clean — 32 pages built, 0 errors

Closes TASK-104 (bughuntertools.com portion).