### PR TITLE
fix: article filter buttons — add client-side JS for static site

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = {
+  testEnvironment: 'node',
+  testMatch: ['**/src/__tests__/**/*.test.js'],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
       },
       "devDependencies": {
         "@11ty/eleventy": "^3.1.2",
-        "jest": "^30.2.0"
+        "jest": "^30.2.0",
+        "picomatch": "^4.0.4"
       }
     },
     "node_modules/@11ty/dependency-tree": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "homepage": "https://github.com/delmarolivier/bughuntertools.com#readme",
   "devDependencies": {
     "@11ty/eleventy": "^3.1.2",
-    "jest": "^30.2.0"
+    "jest": "^30.2.0",
+    "picomatch": "^4.0.4"
   },
   "dependencies": {
     "@astrojs/sitemap": "^3.7.2",

--- a/src/__tests__/articleFilter.test.js
+++ b/src/__tests__/articleFilter.test.js
@@ -1,0 +1,195 @@
+'use strict';
+
+const { getActiveCat, buildUrl, applyFilter, initFilter } = require('../scripts/articleFilter');
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+/** Minimal card mock: tracks display changes and exposes dataset. */
+function makeCard(category) {
+  return { dataset: { category }, style: { display: '' } };
+}
+
+/** Minimal button mock: tracks classList.toggle calls and click listeners. */
+function makeBtn(cat) {
+  const listeners = {};
+  return {
+    dataset: { cat },
+    classList: { toggle: jest.fn() },
+    addEventListener: jest.fn(function (event, handler) {
+      listeners[event] = handler;
+    }),
+    _fire: function (event, arg) {
+      if (listeners[event]) listeners[event](arg);
+    },
+  };
+}
+
+// ─── getActiveCat ───────────────────────────────────────────────────────────
+
+describe('getActiveCat', () => {
+  test('returns "all" for empty search string', () => {
+    expect(getActiveCat('')).toBe('all');
+  });
+
+  test('returns "all" when cat param is absent', () => {
+    expect(getActiveCat('?foo=bar')).toBe('all');
+  });
+
+  test('returns the cat param value when present', () => {
+    expect(getActiveCat('?cat=tools')).toBe('tools');
+  });
+
+  test('handles multiple params — picks cat', () => {
+    expect(getActiveCat('?page=1&cat=research&q=test')).toBe('research');
+  });
+});
+
+// ─── buildUrl ───────────────────────────────────────────────────────────────
+
+describe('buildUrl', () => {
+  test('returns /articles/ for "all"', () => {
+    expect(buildUrl('all')).toBe('/articles/');
+  });
+
+  test('returns query string URL for a specific category', () => {
+    expect(buildUrl('tools')).toBe('/articles/?cat=tools');
+  });
+
+  test('returns query string URL for research category', () => {
+    expect(buildUrl('research')).toBe('/articles/?cat=research');
+  });
+});
+
+// ─── applyFilter ────────────────────────────────────────────────────────────
+
+describe('applyFilter', () => {
+  test('"all" shows every card', () => {
+    const cards = [makeCard('tools'), makeCard('research'), makeCard('bug-bounty')];
+    const btns = [makeBtn('all'), makeBtn('tools')];
+
+    applyFilter('all', cards, btns);
+
+    cards.forEach(c => expect(c.style.display).toBe(''));
+  });
+
+  test('hides cards not matching the active category', () => {
+    const tools = makeCard('tools');
+    const research = makeCard('research');
+    const btns = [makeBtn('tools')];
+
+    applyFilter('tools', [tools, research], btns);
+
+    expect(tools.style.display).toBe('');
+    expect(research.style.display).toBe('none');
+  });
+
+  test('marks the matching button as active', () => {
+    const btns = [makeBtn('all'), makeBtn('tools'), makeBtn('research')];
+    applyFilter('tools', [], btns);
+
+    expect(btns[0].classList.toggle).toHaveBeenCalledWith('active', false);
+    expect(btns[1].classList.toggle).toHaveBeenCalledWith('active', true);
+    expect(btns[2].classList.toggle).toHaveBeenCalledWith('active', false);
+  });
+
+  test('re-shows a previously hidden card when switching to "all"', () => {
+    const card = makeCard('tools');
+    card.style.display = 'none'; // simulates a prior filter
+
+    applyFilter('all', [card], []);
+
+    expect(card.style.display).toBe('');
+  });
+
+  test('works with an empty card list', () => {
+    const btns = [makeBtn('all')];
+    expect(() => applyFilter('tools', [], btns)).not.toThrow();
+  });
+});
+
+// ─── initFilter ─────────────────────────────────────────────────────────────
+
+describe('initFilter', () => {
+  function makeDocWin(searchString, cards, btns) {
+    const popstateListeners = [];
+    return {
+      doc: {
+        querySelectorAll: jest.fn(function (selector) {
+          if (selector === '#article-list .article-card') return cards;
+          if (selector === '.filter-btn') return btns;
+          return [];
+        }),
+      },
+      win: {
+        location: { search: searchString },
+        history: { pushState: jest.fn() },
+        addEventListener: jest.fn(function (event, handler) {
+          if (event === 'popstate') popstateListeners.push(handler);
+        }),
+        _firePopstate: function () {
+          popstateListeners.forEach(fn => fn());
+        },
+      },
+    };
+  }
+
+  test('applies filter on init based on location.search', () => {
+    const cards = [makeCard('tools'), makeCard('research')];
+    const btns = [makeBtn('all'), makeBtn('tools')];
+    const { doc, win } = makeDocWin('?cat=tools', cards, btns);
+
+    initFilter(doc, win);
+
+    expect(cards[0].style.display).toBe('');    // tools — shown
+    expect(cards[1].style.display).toBe('none'); // research — hidden
+  });
+
+  test('clicking a button updates history and re-filters', () => {
+    const cards = [makeCard('tools'), makeCard('research')];
+    const btns = [makeBtn('all'), makeBtn('research')];
+    const { doc, win } = makeDocWin('', cards, btns);
+
+    initFilter(doc, win);
+
+    // Simulate click on "research" button (index 1)
+    const researchBtn = btns[1];
+    expect(researchBtn.addEventListener).toHaveBeenCalledWith('click', expect.any(Function));
+    researchBtn._fire('click', { preventDefault: jest.fn() });
+
+    expect(win.history.pushState).toHaveBeenCalledWith({}, '', '/articles/?cat=research');
+    expect(cards[0].style.display).toBe('none'); // tools — hidden
+    expect(cards[1].style.display).toBe('');     // research — shown
+  });
+
+  test('clicking "all" button navigates to /articles/', () => {
+    const btns = [makeBtn('all')];
+    const { doc, win } = makeDocWin('?cat=tools', [], btns);
+
+    initFilter(doc, win);
+
+    btns[0]._fire('click', { preventDefault: jest.fn() });
+
+    expect(win.history.pushState).toHaveBeenCalledWith({}, '', '/articles/');
+  });
+
+  test('popstate event re-reads location and re-filters', () => {
+    const cards = [makeCard('tools'), makeCard('research')];
+    const btns = [makeBtn('all'), makeBtn('research')];
+    const { doc, win } = makeDocWin('', cards, btns);
+
+    initFilter(doc, win);
+
+    // Simulate browser back — location.search changes to ?cat=research
+    win.location.search = '?cat=research';
+    win._firePopstate();
+
+    expect(cards[0].style.display).toBe('none'); // tools — hidden
+    expect(cards[1].style.display).toBe('');     // research — shown
+  });
+
+  test('registers a popstate listener on win', () => {
+    const { doc, win } = makeDocWin('', [], []);
+    initFilter(doc, win);
+    expect(win.addEventListener).toHaveBeenCalledWith('popstate', expect.any(Function));
+  });
+});

--- a/src/content/articles/securityclaw-gitleaks-git-history-secret-detection-demo-2026.md
+++ b/src/content/articles/securityclaw-gitleaks-git-history-secret-detection-demo-2026.md
@@ -1,0 +1,145 @@
+---
+title: "We Deleted the Key. Gitleaks Found It Anyway. Here's Why."
+description: "A developer deleted a private RSA key from their git repo. Three commits later, SecurityClaw found it in 13.2ms. Here's what happened and what it means for your codebase."
+date: 2026-05-02
+category: research
+tags: [gitleaks, secret-detection, git-history, security-tools, securityclaw]
+---
+
+> **Affiliate Disclosure:** This site contains affiliate links. We earn a commission when you purchase through our links at no additional cost to you.
+
+A developer panics. They accidentally committed a private key. They delete the file, push the commit, take a breath.
+
+They were never safe.
+
+The moment that key was pushed, it was embedded in every past and future clone of that repo. Anyone who pulled before the deletion has it. Anyone who pulls the repo image from a backup, a mirror, or a CI cache may have it. The working tree is clean. The history is not.
+
+We ran SecurityClaw's Gitleaks integration against a deliberately compromised repo designed to mimic real developer mistakes. The scan took **13.2 milliseconds**. It found 9 raw findings across **6 of 8 planted secrets** — including the RSA key the developer "deleted."
+
+---
+
+## The Demo Setup
+
+We created a controlled git repository with 10 commits and 8 secrets planted across realistic locations: config files, source code, environment files, and a key directory. The secrets represent the kinds of credentials developers actually commit by mistake:
+
+1. **AWS Access Key ID** (`AKIAIOSFODNN7EXAMPL3`) → `config/aws.yml`
+2. **AWS Secret Access Key** → `config/aws.yml`
+3. **PostgreSQL database password** → `config/database.yml`
+4. **GitHub PAT reused as a JWT signing secret** → `src/auth/config.py`
+5. **Slack webhook URL** → `config/notifications.json`
+6. **RSA private key** → `keys/deploy_key.pem` — **committed, then deleted in the next commit**
+7. **Stripe live secret key** → `src/payments.py`
+8. **Base64-encoded internal API key** → `.env` — deliberately obfuscated
+
+The deletion commit message read: *"Remove deploy key from repo (oops, was committed by mistake)."* Classic. Committed in `8172da4`, deleted in `a182f88`. Working tree clean.
+
+---
+
+## The Scan
+
+One command:
+
+```bash
+gitleaks detect --source . --report-format json --report-path results.json --verbose
+```
+
+**Result: 9 findings in 13.2ms.**
+
+---
+
+## What Gitleaks Found
+
+| # | Secret Type | Found? | Rule | Why It Matters |
+|---|---|---|---|---|
+| 1 | AWS Access Key ID | ✅ Yes | `aws-access-token` | Pattern match on `AKIA` prefix |
+| 2 | AWS Secret Access Key | ❌ Missed | — | Random 40-char string, no identifiable pattern |
+| 3 | PostgreSQL password (YAML) | ❌ Missed | — | `password:` in YAML not covered by default rules |
+| 4 | GitHub PAT / JWT secret | ✅ Yes | `generic-api-key` | Entropy + variable name combination |
+| 5 | Slack Webhook URL | ✅ Yes | `slack-webhook-url` | Dedicated rule for Slack hook format |
+| 6 | RSA Private Key (deleted) | ✅ **Yes** | `private-key` | **Found in git history — file absent from working tree** |
+| 7 | Stripe Secret Key | ✅ Yes | `stripe-access-token` | 3 raw findings → 1 unique secret (multi-rule match) |
+| 8 | Base64-encoded API key | ✅ **Yes** | `generic-api-key` | **Entropy analysis caught the obfuscation** |
+
+**Score: 6/8 unique secrets. Zero false positives (one low-risk OAuth client ID flagged for triage).**
+
+---
+
+## The Deleted Key Wasn't Gone
+
+The RSA private key was committed in `8172da4`. The developer removed it in the very next commit. If you cloned the repo today and ran `ls keys/`, you'd see nothing.
+
+Gitleaks scans the full git history, not just the current working tree. It walked back through every commit and found the key in its original commit — file path, line number, secret value. The deletion commit is irrelevant to the history.
+
+This is the part that catches developers off guard. **`git rm` removes a file from your working tree. It does not remove it from your history.** Every `git clone` of this repo, past or future, includes that commit object. The key lives on in every full clone, CI cache, mirror, and archive.
+
+The only remediation is:
+1. **Rotate the key immediately** — assume it's compromised.
+2. **Rewrite git history** using `git filter-repo` or BFG Repo Cleaner, then force-push all branches and notify all collaborators.
+3. Or start a new repository if history rewrite is impractical.
+
+Until step 2 is done, the key is in every clone.
+
+---
+
+## Base64 Isn't Encryption
+
+One `.env` entry in the demo repo was encoded:
+
+```
+INTERNAL_API_KEY=aW50ZXJuYWwtc2VjcmV0LWFwaS1rZXktMTIzNDU2Nzg5MA==
+```
+
+The developer even commented: *"This is base64-encoded but still a secret (obfuscation != encryption)"* — and Gitleaks flagged it anyway.
+
+How? **Entropy analysis.** Base64-encoded strings have a characteristic information density of approximately 4.9 bits per character — significantly higher than normal prose or code identifiers. Gitleaks measures the entropy of high-suspicion string values and flags anything that looks anomalously random.
+
+No pattern match was needed. No rule recognized the specific format. High entropy alone was enough to trigger the `generic-api-key` rule.
+
+This is why encoding secrets doesn't help. Base64, hex encoding, simple XOR — they all preserve the entropy signature. The value looks scrambled to a human. It doesn't look scrambled to an entropy detector.
+
+---
+
+## Honest Gaps
+
+**Two secrets were missed, and you should know why.**
+
+**1. AWS Secret Access Key** — Gitleaks has a rule for AWS Key IDs because they have a recognizable prefix (`AKIA...`). The secret access key is a random 40-character alphanumeric string with no distinguishing pattern. Without the access key ID alongside it, Gitleaks can't reliably flag it. TruffleHog's AWS detector checks *both* keys and can verify them live against AWS APIs — that's the gap Gitleaks can't close alone.
+
+**2. PostgreSQL password in YAML** — The default Gitleaks ruleset doesn't cover generic `password: value` patterns in YAML configuration files. This is a deliberate scope decision — a blanket rule would generate too many false positives. A custom `.gitleaks.toml` rule can close this gap for your specific config structure.
+
+These aren't reasons to avoid Gitleaks. They're reasons to understand what any single scanner can and can't do.
+
+---
+
+## The Dual-Scanner Answer
+
+Gitleaks and TruffleHog aren't competing tools. They're complementary.
+
+| Feature | TruffleHog | Gitleaks |
+|---|---|---|
+| Speed | ~2s (same repo) | **13.2ms** |
+| Detectors | 700+ specialized | ~150 rules |
+| Live secret verification | **Yes** (API check) | No |
+| Entropy detection | Limited | **Strong** |
+| Custom rules | Config-based | `.toml` file |
+| Git history scan | Yes | **Yes** |
+| Output formats | JSON | JSON, CSV, SARIF |
+| D-series result | 4/5 planted secrets | 6/8 planted secrets |
+
+Together they close most gaps. Gitleaks runs first: 13ms, catches high-entropy strings and pattern-based secrets, surfaces the deleted-key-in-history problem immediately. TruffleHog runs second: slower, but verifies secrets live — you know whether a found credential is still active.
+
+For YAML passwords and other non-standard secret formats, a `.gitleaks.toml` with custom regex rules adds the final layer.
+
+SecurityClaw runs both in sequence. You can read about the TruffleHog side in our [TruffleHog v3 demo article](/articles/securityclaw-trufflehog-v3-live-secret-verification-demo-2026/).
+
+---
+
+## Try SecurityClaw
+
+SecurityClaw integrates Gitleaks, TruffleHog, and a growing library of security tools into a single campaign-based platform. Run the dual-scanner workflow on your own repos with a single command.
+
+**[Try SecurityClaw free →](https://securityclaw.io)**
+
+---
+
+*SecurityClaw demo D13 — run on securityclaw-kali, 2026-03-11. Research by Peng.*

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -78,46 +78,8 @@ function formatDate(date: Date): string {
     </ul>
   </div>
 <script>
-  (function () {
-    function getActiveCat() {
-      const params = new URLSearchParams(window.location.search);
-      return params.get('cat') || 'all';
-    }
-
-    function applyFilter(cat) {
-      const cards = document.querySelectorAll('#article-list .article-card');
-      cards.forEach(function (card) {
-        if (cat === 'all' || card.dataset.category === cat) {
-          card.style.display = '';
-        } else {
-          card.style.display = 'none';
-        }
-      });
-
-      document.querySelectorAll('.filter-btn').forEach(function (btn) {
-        btn.classList.toggle('active', btn.dataset.cat === cat);
-      });
-    }
-
-    // Apply on page load
-    applyFilter(getActiveCat());
-
-    // Intercept filter clicks — update URL and filter without navigation
-    document.querySelectorAll('.filter-btn').forEach(function (btn) {
-      btn.addEventListener('click', function (e) {
-        e.preventDefault();
-        const cat = btn.dataset.cat || 'all';
-        const url = cat === 'all' ? '/articles/' : '/articles/?cat=' + cat;
-        window.history.pushState({}, '', url);
-        applyFilter(cat);
-      });
-    });
-
-    // Handle back/forward
-    window.addEventListener('popstate', function () {
-      applyFilter(getActiveCat());
-    });
-  })();
+  import { initFilter } from '../../scripts/articleFilter.js';
+  initFilter();
 </script>
 
 </BaseLayout>

--- a/src/pages/articles/index.astro
+++ b/src/pages/articles/index.astro
@@ -37,11 +37,11 @@ function formatDate(date: Date): string {
 
       <nav class="category-filter" aria-label="Filter by category">
         <span class="filter-label">Filter:</span>
-        <a href="/articles/" class="filter-btn active">All ({articles.length})</a>
+        <a href="/articles/" class="filter-btn" data-cat="all">All ({articles.length})</a>
         {Object.entries(categoryMeta).map(([cat, meta]) => {
           const count = articles.filter(a => a.data.category === cat).length;
           return count > 0 ? (
-            <a href={`/articles/?cat=${cat}`} class="filter-btn">
+            <a href={`/articles/?cat=${cat}`} class="filter-btn" data-cat={cat}>
               {meta.icon} {meta.label} ({count})
             </a>
           ) : null;
@@ -49,11 +49,11 @@ function formatDate(date: Date): string {
       </nav>
     </header>
 
-    <ul class="article-list" role="list">
+    <ul class="article-list" role="list" id="article-list">
       {articles.map((article) => {
         const meta = categoryMeta[article.data.category] ?? { label: article.data.category, icon: '📄', color: '#666' };
         return (
-          <li class="article-card">
+          <li class="article-card" data-category={article.data.category}>
             <div class="article-card-meta">
               <span class="category-badge" style={`background: ${meta.color}`}>
                 {meta.icon} {meta.label}
@@ -77,6 +77,49 @@ function formatDate(date: Date): string {
       })}
     </ul>
   </div>
+<script>
+  (function () {
+    function getActiveCat() {
+      const params = new URLSearchParams(window.location.search);
+      return params.get('cat') || 'all';
+    }
+
+    function applyFilter(cat) {
+      const cards = document.querySelectorAll('#article-list .article-card');
+      cards.forEach(function (card) {
+        if (cat === 'all' || card.dataset.category === cat) {
+          card.style.display = '';
+        } else {
+          card.style.display = 'none';
+        }
+      });
+
+      document.querySelectorAll('.filter-btn').forEach(function (btn) {
+        btn.classList.toggle('active', btn.dataset.cat === cat);
+      });
+    }
+
+    // Apply on page load
+    applyFilter(getActiveCat());
+
+    // Intercept filter clicks — update URL and filter without navigation
+    document.querySelectorAll('.filter-btn').forEach(function (btn) {
+      btn.addEventListener('click', function (e) {
+        e.preventDefault();
+        const cat = btn.dataset.cat || 'all';
+        const url = cat === 'all' ? '/articles/' : '/articles/?cat=' + cat;
+        window.history.pushState({}, '', url);
+        applyFilter(cat);
+      });
+    });
+
+    // Handle back/forward
+    window.addEventListener('popstate', function () {
+      applyFilter(getActiveCat());
+    });
+  })();
+</script>
+
 </BaseLayout>
 
 <style>

--- a/src/scripts/articleFilter.js
+++ b/src/scripts/articleFilter.js
@@ -1,0 +1,75 @@
+'use strict';
+
+/**
+ * Parse the active category from a URL query string.
+ * @param {string} search - URL search string (e.g. '?cat=tools')
+ * @returns {string} category key, defaults to 'all'
+ */
+function getActiveCat(search) {
+  var params = new URLSearchParams(search || '');
+  return params.get('cat') || 'all';
+}
+
+/**
+ * Build the canonical URL for a category filter.
+ * @param {string} cat
+ * @returns {string}
+ */
+function buildUrl(cat) {
+  return cat === 'all' ? '/articles/' : '/articles/?cat=' + cat;
+}
+
+/**
+ * Apply a category filter: show/hide cards, mark the active button.
+ * @param {string} cat
+ * @param {Array|NodeList} cards   - elements with dataset.category and style.display
+ * @param {Array|NodeList} buttons - elements with dataset.cat and classList.toggle
+ */
+function applyFilter(cat, cards, buttons) {
+  Array.prototype.forEach.call(cards, function (card) {
+    if (cat === 'all' || card.dataset.category === cat) {
+      card.style.display = '';
+    } else {
+      card.style.display = 'none';
+    }
+  });
+  Array.prototype.forEach.call(buttons, function (btn) {
+    btn.classList.toggle('active', btn.dataset.cat === cat);
+  });
+}
+
+/**
+ * Wire up the article filter to the page. Reads the initial ?cat= param,
+ * applies the filter, then handles click and popstate events.
+ *
+ * @param {Document} [doc] - injectable for testing (defaults to document)
+ * @param {Window}   [win] - injectable for testing (defaults to window)
+ */
+function initFilter(doc, win) {
+  /* globals document, window */
+  doc = doc || document;
+  win = win || window;
+
+  var cards = doc.querySelectorAll('#article-list .article-card');
+  var buttons = doc.querySelectorAll('.filter-btn');
+
+  // Apply on page load
+  applyFilter(getActiveCat(win.location.search), cards, buttons);
+
+  // Intercept filter clicks — update URL and filter without navigation
+  Array.prototype.forEach.call(buttons, function (btn) {
+    btn.addEventListener('click', function (e) {
+      e.preventDefault();
+      var cat = btn.dataset.cat || 'all';
+      win.history.pushState({}, '', buildUrl(cat));
+      applyFilter(cat, cards, buttons);
+    });
+  });
+
+  // Handle back/forward
+  win.addEventListener('popstate', function () {
+    applyFilter(getActiveCat(win.location.search), cards, buttons);
+  });
+}
+
+module.exports = { getActiveCat, buildUrl, applyFilter, initFilter };


### PR DESCRIPTION
## Problem
The category filter buttons on `/articles/` don't work. They link to `?cat=` query params but the page is statically built by Astro — there was no server-side or client-side logic to actually filter the list. The buttons navigated to a new URL but showed all articles regardless.

Reported by Delmar on Chrome iOS (affects all browsers).

## Fix
- Added `data-cat` attributes to filter buttons and `data-category` attributes to each article card
- Added inline `<script>` that reads the `?cat` query param on page load and shows/hides cards accordingly
- Clicking a filter button now uses `history.pushState` to update the URL without a full page reload, then filters inline
- Back/forward navigation handled via `popstate`
- Active button state applied correctly

## Testing
- Build passes: 33 pages, 0 errors
- Works with no JS framework dependencies — plain vanilla JS