### PR TITLE
fix(a11y): scope header/footer CSS to body > header/footer — fix beyondtrust colour-contrast

### DIFF
--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -11,7 +11,7 @@
         "categories:accessibility":  ["error", {"minScore": 0.9}],
         "categories:best-practices": ["warn",  {"minScore": 0.75}],
         "categories:seo":            ["error", {"minScore": 0.9}],
-        "color-contrast":             ["warn",  {"minScore": 0}],
+        "color-contrast":             ["error", {"minScore": 0}],
         "inspector-issues":           ["warn",  {"minScore": 0}],
         "third-party-cookies":        ["warn",  {"minScore": 0}],
         "unused-javascript":         ["warn",  {"maxLength": 3}],

--- a/css/style.css
+++ b/css/style.css
@@ -17,15 +17,15 @@ body {
     padding: 0 20px;
 }
 
-/* Header */
-header {
+/* Header — scoped to body > header to avoid bleeding into article content */
+body > header {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
     padding: 60px 0;
     text-align: center;
 }
 
-header h1 {
+body > header h1 {
     font-size: 2.5rem;
     margin-bottom: 10px;
 }
@@ -333,8 +333,8 @@ pre code {
     background: #229954;
 }
 
-/* Footer */
-footer {
+/* Footer — scoped to body > footer to avoid bleeding into article content */
+body > footer {
     background: #2c3e50;
     color: white;
     text-align: center;
@@ -342,7 +342,7 @@ footer {
     margin-top: 60px;
 }
 
-footer p {
+body > footer p {
     margin: 10px 0;
     opacity: 0.8;
 }
@@ -409,7 +409,7 @@ footer p {
 
 /* Responsive */
 @media (max-width: 768px) {
-    header h1 {
+    body > header h1 {
         font-size: 2rem;
     }
     

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -17,15 +17,15 @@ body {
     padding: 0 20px;
 }
 
-/* Header */
-header {
+/* Header — scoped to body > header to avoid bleeding into article content */
+body > header {
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
     padding: 60px 0;
     text-align: center;
 }
 
-header h1 {
+body > header h1 {
     font-size: 2.5rem;
     margin-bottom: 10px;
 }
@@ -333,8 +333,8 @@ pre code {
     background: #229954;
 }
 
-/* Footer */
-footer {
+/* Footer — scoped to body > footer to avoid bleeding into article content */
+body > footer {
     background: #2c3e50;
     color: white;
     text-align: center;
@@ -342,7 +342,7 @@ footer {
     margin-top: 60px;
 }
 
-footer p {
+body > footer p {
     margin: 10px 0;
     opacity: 0.8;
 }
@@ -409,7 +409,7 @@ footer p {
 
 /* Responsive */
 @media (max-width: 768px) {
-    header h1 {
+    body > header h1 {
         font-size: 2rem;
     }
     


### PR DESCRIPTION
## Problem

The beyondtrust article (`/articles/beyondtrust-rce-cve-2026-1731/`) contains raw HTML in its Markdown file with inner `<header>` and `<footer>` elements. The global CSS selectors `header {}` and `footer {}` were bleeding into these, causing:

- Inner `<header>` → got `linear-gradient(#667eea, #764ba2)` purple background
- `<h1>` inside it → `article h1 { color: #2c3e50 }` (dark navy) on purple gradient = **~2.99:1 contrast**, fails WCAG AA large-text threshold (3:1 minimum)
- Inner `<footer class="article-footer">` → got `#2c3e50` dark background, links using browser default blue fail on dark bg

Lighthouse CI was reporting `color-contrast` score: 0 on the beyondtrust article. `color-contrast` was downgraded to `warn` in .lighthouserc.json as a workaround (commit 5a7a2c7).

## Fix

Scope all site-level header/footer CSS rules to direct children of `<body>`:

| Before | After |
|--------|-------|
| `header { ... }` | `body > header { ... }` |
| `header h1 { ... }` | `body > header h1 { ... }` |
| `footer { ... }` | `body > footer { ... }` |
| `footer p { ... }` | `body > footer p { ... }` |
| `@media header h1 { ... }` | `body > header h1 { ... }` |

Also restores `.lighthouserc.json` `color-contrast` assertion from `warn` back to `error`.

## Verification

- `npm run build`: 37 pages, 0 errors ✅
- `npm test`: 17/17 pass ✅
- `dist/css/style.css`: `body > header` and `body > footer` present, no bare `header {}` or `footer {}` ✅