### PR TITLE
feat: add ClawWorks Weekly newsletter signup widget (Beehiiv, TASK-230)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -102,6 +102,23 @@ const pathname = Astro.url.pathname;
         <slot />
     </main>
 
+    <section class="newsletter-signup">
+      <div class="container">
+        <h2>ClawWorks Weekly</h2>
+        <p>Security research, trading bots, and AI benchmarks — what's actually happening this week.</p>
+        <iframe
+          src="https://embeds.beehiiv.com/pub_89c619ce-28a4-4692-a0d0-6c6215d80355"
+          data-test-id="beehiiv-embed"
+          width="100%"
+          height="320"
+          frameborder="0"
+          scrolling="no"
+          style="border-radius: 4px; border: 2px solid #e5e7eb; margin: 0; background-color: transparent;"
+          title="ClawWorks Weekly newsletter signup"
+        ></iframe>
+      </div>
+    </section>
+
     <footer>
         <div class="container">
             <p>&copy; 2026 Bug Hunter Tools. All rights reserved. | <a href="/privacy/" style="color: white;">Privacy Policy</a></p>
@@ -158,5 +175,36 @@ const pathname = Astro.url.pathname;
 <style>
   nav.main-nav a.active {
     background: rgba(255,255,255,0.2);
+  }
+
+  .newsletter-signup {
+    background: #f8fafc;
+    border-top: 1px solid #e2e8f0;
+    padding: 2.5rem 0 1.5rem;
+  }
+
+  .newsletter-signup .container {
+    max-width: 680px;
+    margin: 0 auto;
+    padding: 0 1.5rem;
+    text-align: center;
+  }
+
+  .newsletter-signup h2 {
+    font-size: 1.4rem;
+    margin: 0 0 0.5rem;
+    color: #1e293b;
+  }
+
+  .newsletter-signup p {
+    color: #64748b;
+    margin: 0 0 1.25rem;
+    font-size: 0.95rem;
+  }
+
+  @media (max-width: 640px) {
+    .newsletter-signup {
+      padding: 1.5rem 0 1rem;
+    }
   }
 </style>


### PR DESCRIPTION
## Summary

Embeds the ClawWorks Weekly newsletter signup widget on every page footer.

**Publication**: ClawWorks Weekly (https://clawworks.beehiiv.com/)
**Pub ID**: pub_89c619ce-28a4-4692-a0d0-6c6215d80355

## Changes

- Added `.newsletter-signup` section above the footer in PageLayout/BaseLayout
- Beehiiv iframe embed (standard Beehiiv embed format)
- 1 heading + 1 tagline + the iframe
- Styled to fit the existing site palette (light background, border, centered, max-width 680px)

## Part of

TASK-230 (Beehiiv newsletter launch) — signup widget embed PRs for all 3 sites. This is the bughuntertools.com version; companion PRs open on botversusbot.com and modelbattles.com.