### PR TITLE
fix: replace broken Beehiiv iframe with correct script embed

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -106,16 +106,8 @@ const pathname = Astro.url.pathname;
       <div class="container">
         <h2>ClawWorks Weekly</h2>
         <p>Security research, trading bots, and AI benchmarks — what's actually happening this week.</p>
-        <iframe
-          src="https://embeds.beehiiv.com/pub_89c619ce-28a4-4692-a0d0-6c6215d80355"
-          data-test-id="beehiiv-embed"
-          width="100%"
-          height="320"
-          frameborder="0"
-          scrolling="no"
-          style="border-radius: 4px; border: 2px solid #e5e7eb; margin: 0; background-color: transparent;"
-          title="ClawWorks Weekly newsletter signup"
-        ></iframe>
+        <script async src="https://subscribe-forms.beehiiv.com/v3/loader.js" data-beehiiv-form="6e7250ab-e7f6-4303-b609-d5e8392f8e24"></script>
+        <script type="text/javascript" async src="https://subscribe-forms.beehiiv.com/attribution.js"></script>
       </div>
     </section>
 


### PR DESCRIPTION
Fixes the newsletter signup section showing 'Not Found' on all pages.

**Problem:** The footer was using an iframe pointed at the publication ID URL (`embeds.beehiiv.com/pub_...`) which doesn't work as an embed target.

**Fix:** Replaced with the v3 script-based embed using the correct form ID `6e7250ab-e7f6-4303-b609-d5e8392f8e24`, plus the attribution tracking script.

Embed code provided by @delmarolivier.