### PR TITLE
fix: remove ca- prefix from ads.txt publisher ID

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,1 +1,1 @@
-google.com, ca-pub-9373816755142401, DIRECT, f08c47fec0942fa0
+google.com, pub-9373816755142401, DIRECT, f08c47fec0942fa0

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -106,16 +106,8 @@ const pathname = Astro.url.pathname;
       <div class="container">
         <h2>ClawWorks Weekly</h2>
         <p>Security research, trading bots, and AI benchmarks — what's actually happening this week.</p>
-        <iframe
-          src="https://embeds.beehiiv.com/pub_89c619ce-28a4-4692-a0d0-6c6215d80355"
-          data-test-id="beehiiv-embed"
-          width="100%"
-          height="320"
-          frameborder="0"
-          scrolling="no"
-          style="border-radius: 4px; border: 2px solid #e5e7eb; margin: 0; background-color: transparent;"
-          title="ClawWorks Weekly newsletter signup"
-        ></iframe>
+        <script async src="https://subscribe-forms.beehiiv.com/v3/loader.js" data-beehiiv-form="6e7250ab-e7f6-4303-b609-d5e8392f8e24"></script>
+        <script type="text/javascript" async src="https://subscribe-forms.beehiiv.com/attribution.js"></script>
       </div>
     </section>
 


### PR DESCRIPTION
Google AdSense requires `pub-XXXXXXXXX` format in ads.txt, not `ca-pub-XXXXXXXXX`. This was causing persistent 'publisher ID not found' errors in AdSense dashboard even though the file was present and accessible. Fixes the ads.txt unauthorized warning.