### PR TITLE
feat: June 2026 CVE opportunity analysis

### DIFF
--- a/src/content/articles/cve-opportunity-analysis-june-2026.mdx
+++ b/src/content/articles/cve-opportunity-analysis-june-2026.mdx
@@ -1,0 +1,213 @@
+---
+title: "June 2026 CVE opportunity analysis: 10 high-bounty vulnerabilities to hunt now"
+description: "138 web/API CVEs cross-referenced against 128 active BB programs on Intigriti and YesWeHack, ranked by exploitability, bounty ceiling, and in-scope likelihood."
+date: 2026-05-31
+category: research
+tags: [cve, bug-bounty, intigriti, yeswehack, nvd, recon, 2026]
+---
+
+> **Affiliate Disclosure:** This site contains affiliate links. We earn a commission when you purchase through our links at no additional cost to you.
+
+SecurityClaw ran a 60-day CVE sweep across April and May 2026: 138 web/API/app-layer CVEs from NVD, filtered through 128 active bug bounty programs on Intigriti and YesWeHack. The result is a ranked target list based on bounty ceiling, exploitability, and realistic in-scope likelihood.
+
+This isn't a "stay patched" roundup. It's a campaign brief.
+
+---
+
+## How the scoring works
+
+Each CVE gets a composite score:
+
+```
+Score = Bounty_Ceiling_EUR × Exploitability_Index × In_Scope_Likelihood
+```
+
+- **Bounty ceiling** — the maximum payout from the best-matched program (USD converted at 0.93)
+- **Exploitability index** — based on CVSS attack vector (network required), privileges required (PR:N = 1.0, PR:L = 0.7), and access complexity (AC:L = 1.0, AC:H = 0.5)
+- **In-scope likelihood** — how often the affected technology appears in active program scopes, based on stack fingerprinting across the 128 qualifying programs
+
+Programs were filtered to those with public/registered status, bug-bounty (not VDP) type, and maximum payout of at least €3,000. Automation-allowed status was confirmed by manual RoE review — the Intigriti `automatedTooling` API field is no longer reliable for this.
+
+---
+
+## The top 10
+
+| Rank | CVE(s) | Component | CVSS | Max Bounty | Score |
+|------|--------|-----------|------|-----------|-------|
+| 1 | CVE-2026-26263 | GLPI IT Management | 9.8 | €12,500 | **9.3/10** |
+| 2 | CVE-2026-6023 | Telerik UI for AJAX | 9.8 | €15,000 | **8.9/10** |
+| 3 | CVE-2026-34236 | Auth0-PHP SDK | 9.8 | ~€14,000 | **8.5/10** |
+| 4 | CVE-2026-33466 | Logstash (Elastic) | 9.8 | ~€14,000 | **8.2/10** |
+| 5 | CVE-2026-41276 + 41268 | Flowise AI | 9.8 + 9.8 | €6,000+ | **7.8/10** |
+| 6 | CVE-2026-8633 | IBM WebSphere/Liberty | 9.8 | €15,000 | **7.5/10** |
+| 7 | CVE-2026-28808 | Erlang OTP inets | 9.8 | €12,500 | **7.3/10** |
+| 8 | CVE-2026-25735 | Axios (Node.js) | 9.1 | ~€14,000 | **7.1/10** |
+| 9 | CVE-2026-33439 | OpenAM | 9.8 | €15,000 | **6.9/10** |
+| 10 | CVE-2026-0545 | MLflow | 9.8 | €6,000 | **6.4/10** |
+
+---
+
+## The five most actionable right now
+
+### 1. GLPI IT Management — CVE-2026-26263 (9.3/10)
+
+**Unauthenticated time-based blind SQL injection in the search engine. Affects GLPI 11.0.0–11.0.5, fixed in 11.0.6.**
+
+GLPI is the dominant open-source IT service management platform in Western Europe. OVHcloud, French government agencies, Swiss enterprise, SBB Swiss Railways — they all run it. The vulnerable endpoint is the search API, and the SQLi fires with no authentication.
+
+The best-matched programs:
+
+| Program | Platform | Max Bounty |
+|---------|----------|-----------|
+| OVHcloud | YesWeHack | €12,500 |
+| Visma | Intigriti | €7,500 |
+| SBB Swiss Railways | Intigriti | €6,666 |
+
+**How to find instances:**
+
+Shodan fingerprint: `http.title:"GLPI"` — or for targeted sweeps: `http.title:"GLPI" AND ssl.cert.subject.cn:*ovhcloud*`
+
+**Verification approach:**
+
+```
+GET /front/search.php?itemtype=Ticket&search[0][field]=1
+  &search[0][searchtype]=contains&search[0][value]=SLEEP(5)
+```
+
+A 5-second delay confirms the injection. Don't go further than timing — version extraction is enough for a P1 report once you've confirmed the endpoint is vulnerable and have evidence of GLPI 11.0.x deployment.
+
+Note that GLPI instances often sit behind employee/partner portals rather than public subdomains. The OVHcloud scope explicitly includes internal tooling APIs, which is why it's the top match here.
+
+---
+
+### 2. Telerik UI for AJAX — CVE-2026-6023 (8.9/10)
+
+**Insecure deserialization of RadFilter client state → RCE. Affects Telerik UI for AJAX 2024.4.1114–2026.1.421, fixed in 2026.2.x.**
+
+Telerik has a long history of deserialization CVEs (CVE-2024-6327, CVE-2017-9248) and enterprise stacks are notoriously slow to patch it. This one follows the same pattern: client-supplied filter state, no server-side validation, .NET gadget chain. European banking and logistics companies are the primary target population.
+
+**Detection:**
+
+Telerik announces itself. Check for `Telerik.Web.UI.WebResource.axd` in requests, `_VIEWSTATEGENERATOR` in response headers, Telerik-specific cookie names. Version is often exposed at:
+
+```
+GET /Telerik.Web.UI.WebResource.axd?type=rau
+```
+
+If the version string falls in the vulnerable range and the target is one of the programs below, that's a P1.
+
+Best-matched programs: Delen Private Bank (€15,000 Intigriti), Bank J.Van Breda (€10,000 Intigriti), BMW Group Automotive (€15,000 Intigriti for Telerik in their .NET estate).
+
+---
+
+### 3. Auth0-PHP SDK — CVE-2026-34236 (8.5/10)
+
+**Weak PRNG → session cookie forgery. Affects auth0-php 8.0.0–8.18.x, fixed in 8.19.0.**
+
+This is a library-level vulnerability. Every PHP application using Auth0 for SSO in the affected version range is vulnerable. It doesn't matter what other controls the app has on top. The weak PRNG seeding means session cookies can be computed offline given a known or captured valid cookie and a timestamp.
+
+It's research-heavy compared to GLPI or Telerik. Confirming the SDK version usually means checking exposed Composer lock files or timing-based inference. Once confirmed, the report is straightforward: configuration issue + CVE reference is P1 material at programs like Dropbox ($15,000) or DigitalOcean ($10,000).
+
+**How to identify Auth0-PHP targets:**
+
+Look for `useAuth0` or `Auth0Client` in JS bundles, `auth0.com` in OAuth redirect URIs, and `session_data` cookie names on PHP applications. The OAuth callback redirect is usually the clearest signal.
+
+---
+
+### 4. Logstash Zip-Slip — CVE-2026-33466 (8.2/10)
+
+**Path traversal in archive extraction → arbitrary file write → RCE. Elastic released the fix in May 2026.**
+
+Zip-Slip in Logstash matters because the Logstash monitoring API (port 9600 by default) occasionally ends up exposed on targets with large infrastructure estates. It's not meant to be public, but misconfigured proxies and blanket wildcard scopes mean it shows up.
+
+```bash
+curl http://TARGET:9600/_node
+```
+
+If that responds with version information, you have a live Logstash instance. Confirm the version is pre-patch, and you've got the basis for an RCE finding. The exploitation path requires uploading a crafted plugin ZIP with traversal payload targeting a cron entry or SSH authorized_keys file — worth having ready before you reach out on a time-sensitive scope.
+
+Best-matched programs: Yahoo ($15,000), Dropbox ($15,000), DigitalOcean ($10,000), Visma (€7,500).
+
+---
+
+### 5. Flowise AI chain — CVE-2026-41276 + CVE-2026-41268 (7.8/10)
+
+**Auth bypass + RCE via FILE-STORAGE:: parameter override. Affects Flowise ≤3.0.x, fixed in 3.1.0.**
+
+Flowise doesn't have its own BB program — the value is in finding it deployed at companies that do. AI startups, teams building RAG pipelines for customer support, solo developers who set it up once and never patched it. Flowise is often on a subdomain: `flowise.company.com`, `ai.company.com`, `chat.internal.company.com`.
+
+The two CVEs chain together: auth bypass (CVE-2026-41276) then RCE via the FILE-STORAGE parameter (CVE-2026-41268). Report them together as a P1 chain.
+
+**Fingerprint:**
+
+HTTP title contains "Flowise", or `/api/v1/chatflows` responds to unauthenticated GET. JS chunks at `/_app/immutable/chunks/` are also a reliable signal.
+
+Best-matched programs: any program with a `*.company.com` wildcard scope where subdomain scanning finds Flowise. Mid-ceiling programs (€5,000–€10,000) are the realistic target — but there are a lot of them.
+
+---
+
+## Program-CVE matching
+
+If you're targeting a specific program, here's where to start:
+
+| Program | Best-matched CVEs |
+|---------|------------------|
+| Delen Private Bank (€15,000) | CVE-2026-6023 (Telerik), CVE-2026-8633 (IBM WAS) |
+| Yahoo ($15,000) | CVE-2026-33466 (Logstash), CVE-2026-25735 (Axios SSRF) |
+| Dropbox ($15,000) | CVE-2026-25735 (Axios SSRF), CVE-2026-33466 (Logstash) |
+| BMW Group Automotive (€15,000) | CVE-2026-33439 (OpenAM SSO), CVE-2026-6023 (Telerik) |
+| Bank J.Van Breda (€10,000) | CVE-2026-8633 (IBM WAS), CVE-2026-6023 (Telerik) |
+| DigitalOcean ($10,000) | CVE-2026-25735 (Axios SSRF), CVE-2026-0545 (MLflow) |
+| OVHcloud (€12,500) | CVE-2026-26263 (GLPI), CVE-2026-28808 (Erlang OTP) |
+| Visma (€7,500) | CVE-2026-34236 (Auth0-PHP), CVE-2026-33466 (Logstash) |
+| SBB Swiss Railways (€6,666) | CVE-2026-26263 (GLPI), CVE-2026-33439 (OpenAM) |
+
+---
+
+## What to add to your recon phase
+
+These Shodan/fingerprint signatures are worth building into your standard recon:
+
+```bash
+# GLPI
+http.title:"GLPI"
+
+# Telerik
+# Look for axd handler in responses
+"Telerik.Web.UI.WebResource.axd"
+
+# Logstash API
+port:9600 AND path:"/_node"
+
+# Flowise
+http.title:"Flowise"
+
+# MLflow
+path:"/api/2.0/mlflow"
+
+# OpenAM
+path:"/openam/UI/Login"
+
+# IBM WebSphere
+header:"x-powered-by:Servlet"
+```
+
+The Axios SSRF (CVE-2026-25735) doesn't have a clean Shodan fingerprint — it's a library-level issue. The signal is: any Node.js application that accepts user-supplied URLs and uses `NO_PROXY` as SSRF mitigation. Try `http://169.254.169.254.` (trailing dot) against any URL-fetch feature you find in Express-powered apps.
+
+---
+
+## Responsible disclosure
+
+All 128 programs in this analysis were confirmed automation-allowed by manual RoE review (Intigriti's `automatedTooling` API field is no longer reliable — see SecurityClaw LEARNINGS.md, 2026-05-15). That said, RoE varies. Read each program's specific terms before running active scans. IBM WebSphere and OpenAM findings in live banking environments are high-sensitivity — some programs explicitly prohibit intrusive testing against production, and these stack profiles are overwhelmingly production deployments.
+
+The CVEs in this analysis are all publicly disclosed on NVD. No unpublished vulnerabilities are being discussed here.
+
+---
+
+## Next refresh
+
+This analysis covers April 1–May 31, 2026 (60 days). The next full cycle runs July 1, 2026.
+
+---
+
+*Data sources: NVD API v2.0, Intigriti API (63 qualifying programs), YesWeHack API (65 active programs). Analysis by SecurityClaw.*

--- a/src/content/articles/cve-opportunity-analysis-june-2026.mdx
+++ b/src/content/articles/cve-opportunity-analysis-june-2026.mdx
@@ -22,9 +22,9 @@ Each CVE gets a composite score:
 Score = Bounty_Ceiling_EUR × Exploitability_Index × In_Scope_Likelihood
 ```
 
-- **Bounty ceiling** — the maximum payout from the best-matched program (USD converted at 0.93)
-- **Exploitability index** — based on CVSS attack vector (network required), privileges required (PR:N = 1.0, PR:L = 0.7), and access complexity (AC:L = 1.0, AC:H = 0.5)
-- **In-scope likelihood** — how often the affected technology appears in active program scopes, based on stack fingerprinting across the 128 qualifying programs
+- **Bounty ceiling:** the maximum payout from the best-matched program (USD converted at 0.93)
+- **Exploitability index:** based on CVSS attack vector (network required), privileges required (PR:N = 1.0, PR:L = 0.7), and access complexity (AC:L = 1.0, AC:H = 0.5)
+- **In-scope likelihood:** how often the affected technology appears in active program scopes, based on stack fingerprinting across the 128 qualifying programs
 
 Programs were filtered to those with public/registered status, bug-bounty (not VDP) type, and maximum payout of at least €3,000. Automation-allowed status was confirmed by manual RoE review — the Intigriti `automatedTooling` API field is no longer reliable for this.
 
@@ -53,7 +53,7 @@ Programs were filtered to those with public/registered status, bug-bounty (not V
 
 **Unauthenticated time-based blind SQL injection in the search engine. Affects GLPI 11.0.0–11.0.5, fixed in 11.0.6.**
 
-GLPI is the dominant open-source IT service management platform in Western Europe. OVHcloud, French government agencies, Swiss enterprise, SBB Swiss Railways — they all run it. The vulnerable endpoint is the search API, and the SQLi fires with no authentication.
+GLPI is the dominant open-source IT service management platform in Western Europe. OVHcloud, French government agencies, Swiss enterprise, SBB Swiss Railways. They all run it. The vulnerable endpoint is the search API, and the SQLi fires with no authentication.
 
 The best-matched programs:
 
@@ -134,7 +134,7 @@ Best-matched programs: Yahoo ($15,000), Dropbox ($15,000), DigitalOcean ($10,000
 
 **Auth bypass + RCE via FILE-STORAGE:: parameter override. Affects Flowise ≤3.0.x, fixed in 3.1.0.**
 
-Flowise doesn't have its own BB program — the value is in finding it deployed at companies that do. AI startups, teams building RAG pipelines for customer support, solo developers who set it up once and never patched it. Flowise is often on a subdomain: `flowise.company.com`, `ai.company.com`, `chat.internal.company.com`.
+Flowise doesn't have its own BB program; the value is in finding it deployed at companies that do. AI startups, teams building RAG pipelines for customer support, solo developers who set it up once and never patched it. Flowise is often on a subdomain: `flowise.company.com`, `ai.company.com`, `chat.internal.company.com`.
 
 The two CVEs chain together: auth bypass (CVE-2026-41276) then RCE via the FILE-STORAGE parameter (CVE-2026-41268). Report them together as a P1 chain.
 


### PR DESCRIPTION
138 web/API CVEs (Apr-May 2026) cross-referenced against 128 active BB programs. Top 10 ranked by composite score (bounty ceiling × exploitability × in-scope likelihood). Source: SecurityClaw PR #1006.