### PR TITLE
fix: quote '2026' tag string — resolve schema error blocking GHA deploy

### DIFF
--- a/src/content/articles/best-bug-bounty-tools-2026.mdx
+++ b/src/content/articles/best-bug-bounty-tools-2026.mdx
@@ -3,7 +3,7 @@ title: "Best tools for bug bounty hunters in 2026"
 description: "The tools security researchers actually use for recon, scanning, exploitation, and reporting. No filler. Just what works on live programs in 2026."
 date: 2026-05-31
 category: bug-bounty
-tags: [tools, bug-bounty, burp-suite, recon, 2026]
+tags: [tools, bug-bounty, burp-suite, recon, "2026"]
 ---
 
 > **Affiliate Disclosure:** This site contains affiliate links. We earn a commission when you purchase through our links at no additional cost to you.


### PR DESCRIPTION
## Problem

PR #55 (fix/best-bug-bounty-tools-tag-schema) was conflicting with main — the branch was based on pre-PR-#54 history, so GitHub couldn't merge it.

## Fix

Created clean branch from current main. Single-line fix: quoted `2026` as `"2026"` in tags frontmatter.

Before: `tags: [tools, bug-bounty, burp-suite, recon, 2026]`
After:  `tags: [tools, bug-bounty, burp-suite, recon, "2026"]`

This resolves the `[InvalidContentEntryDataError] articles → best-bug-bounty-tools-2026` GHA failure that's been blocking deploys since PR #54 merged.

## Impact
- Unblocks GHA deploy
- Both articles go live: /articles/best-bug-bounty-tools-2026/ + /articles/cve-opportunity-analysis-june-2026/

Closes #55