### PR TITLE
fix: quote '2026' tag string in CVE article — schema error blocking GHA deploy

### DIFF
--- a/src/content/articles/cve-opportunity-analysis-june-2026.mdx
+++ b/src/content/articles/cve-opportunity-analysis-june-2026.mdx
@@ -3,7 +3,7 @@ title: "June 2026 CVE opportunity analysis: 10 high-bounty vulnerabilities to hu
 description: "138 web/API CVEs cross-referenced against 128 active BB programs on Intigriti and YesWeHack, ranked by exploitability, bounty ceiling, and in-scope likelihood."
 date: 2026-05-31
 category: research
-tags: [cve, bug-bounty, intigriti, yeswehack, nvd, recon, 2026]
+tags: [cve, bug-bounty, intigriti, yeswehack, nvd, recon, "2026"]
 ---
 
 > **Affiliate Disclosure:** This site contains affiliate links. We earn a commission when you purchase through our links at no additional cost to you.


### PR DESCRIPTION
Same tag schema issue as PR #56, now in `cve-opportunity-analysis-june-2026.mdx`. The integer `2026` in the tags array fails Astro's schema validation (expects string). This fix unblocks GHA deploy for both BHT articles.