### PR TITLE
content: add affiliate CTAs to existing tool articles (TASK-553)

### DIFF
--- a/src/content/articles/bug-bounty-starter-kit.mdx
+++ b/src/content/articles/bug-bounty-starter-kit.mdx
@@ -243,9 +243,9 @@ Secure your accounts. As a security researcher, you're a high-value target. 2FA 
 
 
 
-- **Shodan Membership:** $59/month - Internet-wide scanning
+- **Shodan Membership:** $59/month - Internet-wide scanning - [Get Shodan →](https://www.shodan.io/store/member)
 
-- **VPS (DigitalOcean/Linode):** $20/month - Remote recon infrastructure
+- **VPS (DigitalOcean/Linode):** $20/month - Remote recon infrastructure - [DigitalOcean →](https://www.digitalocean.com) | [Linode →](https://www.linode.com)
 
 - **VPN (Mullvad/NordVPN):** $5-10/month - Privacy and multi-region testing
 
@@ -428,11 +428,11 @@ Secure your accounts. As a security researcher, you're a high-value target. 2FA 
 
 - **bWAPP:** Buggy web application with 100+ vulnerabilities
 
-- **HackTheBox:** $10/month for VIP, tons of vulnerable machines
+- **HackTheBox:** $10/month for VIP, tons of vulnerable machines - [Sign up →](https://hackthebox.com)
 
 - **PortSwigger Web Security Academy:** Free, interactive labs
 
-- **TryHackMe:** $10/month, guided learning paths
+- **TryHackMe:** $10/month, guided learning paths - [Sign up →](https://tryhackme.com)
 
 
 

--- a/src/content/articles/burp-suite-pricing-2026.mdx
+++ b/src/content/articles/burp-suite-pricing-2026.mdx
@@ -194,6 +194,8 @@ To be clear: Burp Suite Pro is an excellent investment in the right contexts.
 
 The ROI case for Burp Pro at $449/yr is strong. The cost conversation gets harder when you scale to teams, move into Enterprise pricing, and look at what the full bill covers versus what your team actually needs to test.
 
+[Get Burp Suite Professional →](https://portswigger.net/burp/pro)
+
 
 
 


### PR DESCRIPTION
Adds contextual affiliate-friendly links to two existing tool articles.

**Changes:**
- `burp-suite-pricing-2026.mdx`: adds 'Get Burp Suite Professional →' CTA at conclusion
- `bug-bounty-starter-kit.mdx`: links HackTheBox, TryHackMe (Home Lab section), Shodan, DigitalOcean/Linode (Premium Subscriptions section)

**Revenue context (TASK-553):** Part of affiliate quick-wins initiative from Peng's REVENUE_OPPORTUNITIES_2026_06.md. These are direct product links now; referral tracking codes to be swapped in after affiliate program enrollment (PortSwigger Impact, HackTheBox, TryHackMe, DigitalOcean).

**No functional changes** — content-only, no MDX component changes.