### PR TITLE
feat: AI SEO — add llms.txt + FAQ answer-blocks (TASK-652)

### DIFF
--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,66 @@
+# bughuntertools.com
+
+> BugHunterTools is a security research and bug bounty resource built on live campaign data from SecurityClaw, an AI-assisted offensive security pipeline. Every article is grounded in real tooling, real programs, and real vulnerability findings — not theoretical walkthroughs. Our research covers CVE analysis, bug bounty tool reviews, recon techniques, and AI-assisted security workflows.
+
+## Content Categories
+
+- CVE Analysis: In-depth coverage of critical and high-severity vulnerabilities affecting web applications, AI infrastructure, and enterprise software, with exploit mechanics and bug bounty implications
+- Bug Bounty Tools: Practical tool guides and comparisons for Burp Suite, Nuclei, subfinder, sqlmap, ffuf, and other widely-used security research tools
+- SecurityClaw Demos: Live demonstrations of SecurityClaw's AI-assisted reconnaissance, scanning, and exploitation pipeline on real targets
+- Security Research Methodology: Guides on false positive triage, CORS/OAuth attack chains, open redirect analysis, and bounty submission strategy
+- Vulnerability Roundups: Monthly CVE intelligence digests identifying high-opportunity targets with active bug bounty programs
+
+## Key Articles
+
+- Best Bug Bounty Tools in 2026: /articles/best-bug-bounty-tools-2026/
+- Security Testing Tools Guide 2026: /articles/security-testing-tools-2026/
+- Bug Bounty Starter Kit — What You Actually Need: /articles/bug-bounty-starter-kit/
+- Automated Penetration Testing Guide 2026: /articles/automated-penetration-testing-guide-2026/
+- Bug Bounty Submission Guide (Intigriti, HackerOne, Bugcrowd, YesWeHack): /articles/bug-bounty-submission-guide-intigriti-hackerone-bugcrowd-yeswehack-2026/
+- Why Your Security Scanner Isn't a Penetration Test: /articles/why-your-security-scanner-isnt-a-penetration-test/
+- CVE Intelligence for Bug Bounty — Using the NVD API: /articles/cve-intelligence-bug-bounty-nvd-api-2026/
+- CVE Opportunity Analysis — June 2026: /articles/cve-opportunity-analysis-june-2026/
+- CORS Misconfiguration in EU Bug Bounty Targets: /articles/cors-misconfiguration-eu-bug-bounty-2026/
+- CORS + OAuth Compound Chain (Account Takeover): /articles/cors-oauth-compound-chain-account-takeover-2026/
+- Open Redirect Scanner False Positives — What Your Scanner Gets Wrong: /articles/open-redirect-scanner-false-positives-bug-bounty-2026/
+- JavaScript Bundle Secrets — EU SaaS Recon 2026: /articles/js-bundle-secrets-eu-saas-recon-2026/
+- JS Bundle Analysis False Positives in Bug Bounty: /articles/js-bundle-false-positives-bug-bounty-2026/
+- Subdomain Takeover — EU Bounty Targets 2026: /articles/subdomain-takeover-eu-bounty-targets-2026/
+- Security Lab Setup Guide 2026: /articles/security-lab-setup-guide-2026/
+- Burp Suite Pricing 2026 — Is Pro Worth It?: /articles/burp-suite-pricing-2026/
+
+## CVE Coverage
+
+- CVE-2026-22778 (vLLM RCE, CVSS 9.8): /articles/vllm-rce-cve-2026-22778/
+- CVE-2026-21329 (Adobe After Effects RCE): /articles/adobe-after-effects-cve-2026-21329/
+- CVE-2026-1731 (BeyondTrust RCE): /articles/beyondtrust-rce-cve-2026-1731/
+- CVE-2026-22218 (Chainlit AI Vulnerabilities): /articles/chainlit-ai-vulnerabilities-cve-2026-22218/
+- CVE-2026-22769 (Dell RecoverPoint): /articles/dell-recoverpoint-cve-2026-22769/
+- CVE-2026-2473 (GCP Vertex AI Bucket Squatting): /articles/gcp-vertex-ai-bucket-squatting-cve-2026-2473/
+- CVE-2026-21513 (MSHTML): /articles/mshtml-cve-2026-21513/
+- CVE-2026-21858 (n8n RCE): /articles/n8n-rce-cve-2026-21858/
+- CVE-2026-25049 (n8n RCE 2): /articles/n8n-rce-cve-2026-25049/
+- Firefox SpiderMonkey WASM GC RCE: /articles/firefox-spidermonkey-wasm-gc-rce/
+- LinkedIn API BOLA Bypass: /articles/linkedin-api-bola-bypass/
+- Microsoft Patch Tuesday February 2026 Zero Days: /articles/microsoft-patch-tuesday-february-2026-zero-days/
+- RoguePilot — GitHub Copilot Prompt Injection: /articles/roguepilot-github-copilot-prompt-injection/
+- VSCode Extensions CVE-2025-65717: /articles/vscode-extensions-cve-2025-65717/
+
+## SecurityClaw Pipeline Articles
+
+- SecurityClaw AI Planner — Bedrock Validated: /articles/securityclaw-ai-planner-bedrock-validated-2026/
+- SecurityClaw Campaign Dashboard Pipeline: /articles/securityclaw-campaign-dashboard-pipeline-2026/
+- SecurityClaw BOL Subdomain Recon (Staging Demo): /articles/securityclaw-bol-subdomain-recon-staging-demo-2026/
+- SecurityClaw Campaign 004 — BOL EC2 Run: /articles/securityclaw-campaign-004-bol-ec2-run-2026/
+- SecurityClaw Campaign 005 — BOL Validation: /articles/securityclaw-campaign-005-bol-validation-2026/
+- SecurityClaw CT Logs — Certificate Transparency Passive Recon: /articles/securityclaw-ct-logs-certificate-transparency-passive-recon-2026/
+- SecurityClaw Gitleaks — Git History Secret Detection: /articles/securityclaw-gitleaks-git-history-secret-detection-demo-2026/
+- SecurityClaw Gobuster — Directory Enumeration Demo: /articles/securityclaw-gobuster-directory-enumeration-demo-2026/
+- SecurityClaw Nuclei — Misconfiguration Scanner Demo: /articles/securityclaw-nuclei-misconfiguration-scanner-demo-2026/
+- SecurityClaw sqlmap — SQL Injection Demo: /articles/securityclaw-sqlmap-sql-injection-demo-2026/
+- SecurityClaw TruffleHog v3 — Live Secret Verification: /articles/securityclaw-trufflehog-v3-live-secret-verification-demo-2026/
+- SecurityClaw WAF Bypass (BOL): /articles/securityclaw-kali-waf-bypass-bol-2026/
+
+## About
+
+BugHunterTools is published by the ClawWorks team. Security research is conducted by Peng (SecurityClaw pipeline). Content is grounded in live campaign data — tools and techniques are tested before they are recommended.

--- a/src/content/articles/best-bug-bounty-tools-2026.mdx
+++ b/src/content/articles/best-bug-bounty-tools-2026.mdx
@@ -194,3 +194,35 @@ A few things that show up on "bug bounty tools" lists that aren't worth your tim
 | VPS | DigitalOcean | No ($6/mo) | OOB callbacks |
 
 The single best investment if you're just starting: Burp Suite Pro + a TryHackMe Premium month to get up to speed on the Web Fundamentals path. Everything else builds on top of that.
+
+---
+
+## Frequently Asked Questions
+
+### What is the best tool for bug bounty hunting in 2026?
+
+Burp Suite Professional is the essential starting point for web and API bug bounty. It provides an intercepting proxy, active scanner, Collaborator for out-of-band detection, and a full extension API. For recon, the ProjectDiscovery stack (subfinder + httpx + nuclei) covers subdomain enumeration, live host detection, and automated misconfiguration scanning — all free.
+
+### Is Burp Suite Community Edition enough for bug bounty?
+
+Burp Suite Community Edition covers the basics — intercepting proxy, Repeater, Decoder — but has significant limitations for serious bug bounty work. Intruder is rate-throttled (unusable for fuzzing at scale), the active scanner is unavailable, and Collaborator for blind SSRF/OOB detection is not included. For systematic bug hunting, Burp Suite Professional ($449/year) is the standard investment.
+
+### What free tools do bug bounty hunters use?
+
+The core free toolkit: subfinder (subdomain enumeration), httpx (live host probing and tech fingerprinting), nuclei (automated vulnerability scanning with community templates), ffuf (directory and parameter fuzzing), amass (active and passive DNS enumeration), sqlmap (SQL injection confirmation and PoC), Shodan free tier (exposed service discovery), and Web Security Academy (PortSwigger's free web vulnerability lab). All are actively maintained in 2026.
+
+### How much does it cost to set up a bug bounty toolkit?
+
+A minimal serious toolkit: Burp Suite Pro ($449/year) + a VPS for OOB callbacks (~$72/year for DigitalOcean basic). Everything else — subfinder, httpx, nuclei, ffuf, sqlmap — is free and open source. Total first-year cost: approximately $521. Optional: Shodan membership ($49 one-time) for systematic recon sweeps.
+
+### What is nuclei and how is it used in bug bounty?
+
+Nuclei is a fast, template-based vulnerability scanner from ProjectDiscovery. It runs a library of community-written templates against targets to detect misconfigurations, exposed admin interfaces, outdated software, and known CVEs. In bug bounty, nuclei is used for initial automated discovery before manual investigation. Keep templates updated with `nuclei -update-templates` before each campaign.
+
+### What tools do you use for subdomain enumeration?
+
+The standard combination is subfinder (passive enumeration from certificate transparency logs, DNS brute force, and API sources) piped into httpx (probing which subdomains are live, grabbing status codes and tech stack). One command: `subfinder -d target.com -silent | httpx -status-code -title -tech-detect -o recon-output.txt`. Both are free and in the ProjectDiscovery toolkit.
+
+### When is Shodan worth paying for in bug bounty?
+
+Shodan's free tier covers basic searches. The paid API ($49/month or one-time membership) is worth it if you run systematic recon sweeps across multiple targets, need high rate limits, or want to use advanced filters like `ssl.cert.subject.cn:*target.com` combined with service-specific queries. For occasional use, the free tier is sufficient.


### PR DESCRIPTION
## AI SEO: llms.txt + FAQ answer-blocks

**Part of TASK-652** — AI SEO prep across all 3 sites.

### What's in this PR

**1. Add `/llms.txt` (new file)**

Per the [llmstxt.org](https://llmstxt.org) emerging standard. Full site index for AI crawlers with:
- Site description and content categories
- Key articles indexed by URL
- CVE coverage section
- SecurityClaw pipeline articles section
- About section

**2. FAQ answer-blocks on `best-bug-bounty-tools-2026.mdx`**

Added 7-question FAQ section covering:
- Best tool for bug bounty hunting
- Community vs Pro Burp Suite edition
- Free tools available
- Toolkit cost breakdown
- nuclei usage
- Subdomain enumeration tools
- Shodan paid vs free

### Why

Our benchmark and security research content is citation-worthy. llms.txt makes it discoverable to AI crawlers (ChatGPT, Perplexity, Claude). FAQ answer-blocks make individual article content extractable and citation-ready. `security-testing-tools-2026.mdx` already had strong FAQ structure — `best-bug-bounty-tools-2026.mdx` was the gap.

### Companion PRs
- botversusbot.com: `feat/llms-txt-answer-blocks`
- modelbattles.com: `feat/llms-txt-answer-blocks`
