### PR TITLE
fix: suppress duplicate Article JSON-LD in BaseLayout (TASK-654)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -55,13 +55,17 @@ const pathname = Astro.url.pathname;
     <link rel="preconnect" href="https://www.google-analytics.com">
 
     <!-- Schema.org markup -->
-    <script type="application/ld+json" set:html={JSON.stringify({
-      "@context": "https://schema.org",
-      "@type": schemaType,
-      "name": title,
-      "description": description,
-      "url": pageUrl
-    })} />
+    {/* When isArticle=true, ArticleLayout injects a complete Article JSON-LD via head-extra.
+        Suppress the generic block here to avoid duplicate/incomplete Article schema. */}
+    {!isArticle && (
+      <script type="application/ld+json" set:html={JSON.stringify({
+        "@context": "https://schema.org",
+        "@type": schemaType,
+        "name": title,
+        "description": description,
+        "url": pageUrl
+      })} />
+    )}
     <slot name="head-extra" />
 </head>
 <body>


### PR DESCRIPTION
## What

BHT article pages were emitting two `Article` JSON-LD blocks:
- Block 1 (legacy, from BaseLayout): `name` / `description` / `url` only — **no** `headline`, no `datePublished`, no author
- Block 2 (new, from ArticleLayout head-extra slot): complete schema with all required fields

Google's Rich Results Test sees both blocks. Block 1 fails validation (missing `headline`).

## Fix

In `BaseLayout.astro`: skip the generic JSON-LD block when `isArticle=true`. ArticleLayout already injects a complete Article schema via `<slot name="head-extra" />`.

## Smoke

```
npm run build → 57 pages, 0 errors
Article pages: 1 JSON-LD block each (headline ✅, datePublished ✅, author ✅, publisher ✅)
FAQPage microdata: present on FAQ articles ✅
```

## Context

TASK-654 (Schema markup) — follow-up fix identified during Google Rich Results Test validation step.