### PR TITLE
feat: add affiliate disclosure to footer (TASK-694)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -133,6 +133,7 @@ const pathname = Astro.url.pathname;
     <footer>
         <div class="container">
             <p>&copy; 2026 Bug Hunter Tools. All rights reserved. | <a href="/privacy/" style="color: white;">Privacy Policy</a></p>
+            <p style="font-size: 0.8rem; opacity: 0.75; margin-top: 0.5rem;">This site contains affiliate links. If you purchase a product through one of these links, we may earn a commission at no additional cost to you. We only recommend tools we would use ourselves.</p>
         </div>
     </footer>
 


### PR DESCRIPTION
## Summary

Adds mandatory affiliate disclosure text to the site footer ahead of affiliate programme enrolments.

Required by FTC guidelines and GDPR for any site with affiliate links. Gets this in place before the actual link placement work begins.

## Disclosure text added

> This site contains affiliate links. If you purchase a product through one of these links, we may earn a commission at no additional cost to you. We only recommend tools we would use ourselves.

Placement: below the copyright line in BaseLayout.astro footer.

## Smoke evidence

- Build: ✅ 57 pages, 0 errors, 3.93s
- Disclosure rendered: ✅ `grep -c "affiliate links" dist/index.html` → 1
- No layout regressions

## Related

TASK-694 (Carbon Ads + affiliate revenue activation for bughuntertools.com)